### PR TITLE
[LTC] Autogen `rsqrt` and `sigmoid` for TS backend

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -944,8 +944,6 @@ class LazyTensor {
                                               const at::Scalar& upper,
                                               bool training);
 
-  static LazyTensor rsqrt(const LazyTensor& input);
-
   static LazyTensor rsub(
       const LazyTensor& input, const LazyTensor& other, const at::Scalar& alpha,
       c10::optional<at::ScalarType> logical_element_type = c10::nullopt);
@@ -975,7 +973,7 @@ class LazyTensor {
                            lazy_tensors::int64 index);
 
   static void silu_out(LazyTensor& input, LazyTensor& out);
-  static LazyTensor sigmoid(const LazyTensor& input);
+
   static LazyTensor sigmoid_backward(const LazyTensor& grad_output,
                                      const LazyTensor& output);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -2159,10 +2159,6 @@ LazyTensor LazyTensor::rrelu_with_noise_backward(const LazyTensor& grad_output,
       upper, training));
 }
 
-LazyTensor LazyTensor::rsqrt(const LazyTensor& input) {
-  return input.CreateFrom(ir::ops::Rsqrt(input.GetIrValue()));
-}
-
 LazyTensor LazyTensor::rsub(
     const LazyTensor& input, const LazyTensor& other, const at::Scalar& alpha,
     c10::optional<at::ScalarType> logical_element_type) {
@@ -2257,10 +2253,6 @@ LazyTensor LazyTensor::select(const LazyTensor& input, lazy_tensors::int64 dim,
 
 void LazyTensor::silu_out(LazyTensor& input, LazyTensor& out) {
   out.SetInPlaceIrValue(ir::ops::SiLU(input.GetIrValue()));
-}
-
-LazyTensor LazyTensor::sigmoid(const LazyTensor& input) {
-  return input.CreateFrom(ir::ops::Sigmoid(input.GetIrValue()));
 }
 
 LazyTensor LazyTensor::sigmoid_backward(const LazyTensor& grad_output,

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -16,6 +16,8 @@ full_codegen:
   - mv
   - native_layer_norm
   - native_layer_norm_backward
+  - rsqrt
+  - sigmoid
   - topk
 supported:
   - add.Tensor


### PR DESCRIPTION
Summary:
This commit adds code-gen support for rsqrt and sigmoid.

Test Plan:
test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestRsqrt*
test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestSigmoid*
