### PR TITLE
[LTC] Add `c10::optional<at::Scalar>` code-gen support

### DIFF
--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -401,16 +401,6 @@ class LazyTensor {
 
   static LazyTensor cholesky(const LazyTensor& input, bool upper);
 
-  static LazyTensor clamp(const LazyTensor& input,
-                          const c10::optional<at::Scalar>& min,
-                          const c10::optional<at::Scalar>& max);
-  static LazyTensor clamp(const LazyTensor& input,
-                          const c10::optional<at::Tensor>& min,
-                          const c10::optional<at::Tensor>& max);
-  static void clamp_out(LazyTensor& out, const LazyTensor& input,
-                        const c10::optional<at::Tensor>& min,
-                        const c10::optional<at::Tensor>& max);
-
   static LazyTensor clone(const LazyTensor& input);
 
   // Pad with the given value and size specified by the given list of low and

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -8,6 +8,7 @@ full_codegen:
   - addcdiv
   - addcmul
   - cos
+  - clamp
   - dropout
   - gelu
   - gelu_backward

--- a/tools/codegen/api/lazy.py
+++ b/tools/codegen/api/lazy.py
@@ -45,24 +45,13 @@ def process_ir_type(typ: Type) -> Union[BaseCType, VectorCType, OptionalCType, L
         else:
             raise AssertionError(f"TODO add support for type {repr(typ)}")
     elif isinstance(typ, OptionalType):
-        if str(typ.elem) == 'Tensor':
-            return OptionalCType(BaseCType(valueT))
-        elif str(typ.elem) == 'ScalarType':
-            return OptionalCType(BaseCType(scalarTypeT))
-        else:
-            raise AssertionError(f"TODO add support for type {repr(typ)}")
+        return OptionalCType(process_ir_type(typ.elem))
     elif isinstance(typ, ListType):
-        if str(typ.elem) == 'Tensor':
-            return VectorCType(BaseCType(valueT))
-        elif str(typ.elem) == 'Tensor?':
+        if str(typ.elem) == 'Tensor?':
             # TODO(whc) is this actually correct? or should it use a Vector like above
             return ListCType(OptionalCType(BaseCType(valueT)))
-        elif str(typ.elem) == 'int':
-            return VectorCType(BaseCType(longT))
-        elif str(typ.elem) == 'bool':
-            return VectorCType(BaseCType(boolT))
         else:
-            raise AssertionError(f"TODO add support for type {repr(typ)}")
+            return VectorCType(process_ir_type(typ.elem))
     else:
         raise AssertionError(f"unrecognized type {repr(typ)}")
 


### PR DESCRIPTION
Summary:
This commit adds code-gen support for the c10::optional<at::Scalar>
type, and adds full_codegen support for the clamp op to test the
implementation.

Test Plan:
test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestClamp*

Fixes #{issue number}
