### PR TITLE
[LTC] Implement `full_codegen` for ops with overloaded names

### DIFF
--- a/aten/src/ATen/templates/LazyTsLowering.cpp
+++ b/aten/src/ATen/templates/LazyTsLowering.cpp
@@ -45,11 +45,8 @@ ${lowering_definitions}
 TSOpVector LowerToTSCodegen(std::shared_ptr<torch::jit::GraphFunction> function,
                             ts_backend::TSLoweringContext* loctx,
                             const ir::Node* node) {
-    switch (node->op().op){
     ${lowering_dispatches}
-    default:
-        return {};
-    }
+    return {};
 }
 
 } // namespace compiler

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/bitwise_ir_ops.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/bitwise_ir_ops.cpp
@@ -15,10 +15,6 @@ Value BitwiseOp(const OpKind& kind, const Value& node1, const Value& node2) {
   return node;
 }
 
-Value BitwiseAnd(const Value& node1, const Value& node2) {
-  return BitwiseOp(OpKind(at::aten::__and__), node1, node2);
-}
-
 Value BitwiseOr(const Value& node1, const Value& node2) {
   return BitwiseOp(OpKind(at::aten::__or__), node1, node2);
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ops/bitwise_ir_ops.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ops/bitwise_ir_ops.h
@@ -7,7 +7,6 @@ namespace ir {
 namespace ops {
 
 // Value has implicit cast to bool, operator overloads would be confusing.
-Value BitwiseAnd(const Value& node1, const Value& node2);
 Value BitwiseOr(const Value& node1, const Value& node2);
 Value BitwiseXor(const Value& node1, const Value& node2);
 

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor.h
@@ -365,12 +365,6 @@ class LazyTensor {
   static void logical_and_out(LazyTensor& out, const LazyTensor& input,
                               const LazyTensor& other);
 
-  static LazyTensor bitwise_and(const LazyTensor& input,
-                                const at::Scalar& other);
-
-  static LazyTensor bitwise_and(const LazyTensor& input,
-                                const LazyTensor& other);
-
   static void bitwise_not_out(LazyTensor& out, const LazyTensor& input);
 
   static void bitwise_or_out(LazyTensor& out, const LazyTensor& input,

--- a/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/tensor_methods.cpp
@@ -767,21 +767,6 @@ void LazyTensor::logical_and_out(LazyTensor& out, const LazyTensor& input,
   out.SetIrValue(ir::ops::LogicalAnd(input.GetIrValue(), other.GetIrValue()));
 }
 
-LazyTensor LazyTensor::bitwise_and(const LazyTensor& input,
-                                   const at::Scalar& other) {
-  CheckIsIntegralOrPred(input.shape(), "__and__");
-  ir::Value constant =
-      GetIrValueForScalar(other, input.shape(), input.GetDevice());
-  return input.CreateFrom(ir::ops::BitwiseAnd(input.GetIrValue(), constant));
-}
-
-LazyTensor LazyTensor::bitwise_and(const LazyTensor& input,
-                                   const LazyTensor& other) {
-  CheckIsIntegralOrPred(input.shape(), "__and__");
-  return input.CreateFrom(
-      ir::ops::BitwiseAnd(input.GetIrValue(), other.GetIrValue()));
-}
-
 void LazyTensor::bitwise_not_out(LazyTensor& out, const LazyTensor& input) {
   out.SetIrValue(ir::ops::Not(input.GetIrValue()));
 }

--- a/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.cpp
+++ b/lazy_tensor_core/lazy_tensor_core/csrc/ts_backend/LazyShapeDtype.cpp
@@ -89,6 +89,14 @@ std::vector<c10::ScalarType> compute_dtype_mv(const at::Tensor& self, const at::
   return {self.scalar_type()};
 }
 
+std::vector<std::vector<int64_t>> compute_shape_bitwise_and(const at::Tensor& self, const at::Scalar& other) {
+  return {self.sizes().vec()};
+}
+
+std::vector<c10::ScalarType> compute_dtype_bitwise_and(const at::Tensor& self, const at::Scalar& other) {
+  return {self.scalar_type()};
+}
+
 } // namespace ops
 } // namespace ir
 } // namespace torch_lazy_tensors

--- a/lazy_tensor_core/ts_native_functions.yaml
+++ b/lazy_tensor_core/ts_native_functions.yaml
@@ -7,6 +7,8 @@ full_codegen:
   - _softmax_backward_data
   - addcdiv
   - addcmul
+  - bitwise_and.Scalar
+  - bitwise_and.Tensor
   - cos
   - dropout
   - gelu

--- a/tools/codegen/api/lazy.py
+++ b/tools/codegen/api/lazy.py
@@ -128,12 +128,19 @@ class LazyIrSchema:
 
     @property
     def node_name(self) -> str:
-        op_name = str(self.name).lower()
-        return ''.join(word.capitalize() or '' for word in op_name.split('_'))
+        """
+        Return camel-case version of op in node.
+
+        Note: This function also appends any `overload_name` in the operation.
+        For example, if the op is `bitwise_and.Tensor`, the returned name
+        will be `BitwiseAndTensor`.
+        """
+        op_name = f"{self.name.name}_{self.name.overload_name}".lower()
+        return "".join(word.capitalize() or "" for word in op_name.split("_"))
 
     @property
     def aten_name(self) -> str:
-        return f"{self.name}"
+        return f"{self.name.name}"
 
     def filtered_types(self, positional: bool = True, keyword: bool = True,
                        values: bool = True, scalars: bool = True) -> List[NamedCType]:

--- a/tools/codegen/gen_lazy_tensor.py
+++ b/tools/codegen/gen_lazy_tensor.py
@@ -82,8 +82,8 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
     backend_indices = parsed_backend_yaml.backend_indices
     full_codegen = parse_full_codegen_ops(source_yaml, grouped_native_functions)
 
-    def concatMapCodegen(func: Callable[[NativeFunction], Sequence[str]],
-                         xs: Iterable[Union[NativeFunctionsGroup, NativeFunction]]) -> Iterator[str]:
+    def concat_map_codegen(func: Callable[[NativeFunction], Sequence[str]],
+                           xs: Iterable[Union[NativeFunctionsGroup, NativeFunction]]) -> Iterator[str]:
         for x in xs:
             f = x.functional if isinstance(x, NativeFunctionsGroup) else x
             if f.func.name in full_codegen:
@@ -128,7 +128,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
             'native_functions_include': '',
             'backend_namespace': 'torch_lazy_tensors',  # this is wrong
             'native_function_definitions':
-            list(concatMapCodegen(
+            list(concat_map_codegen(
                 lambda f: dest.gen_lazy_nativefunc_definition(
                     f,
                     backend_indices[backend_dispatch_key],
@@ -151,7 +151,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
             ]],
             'DispatchKey': backend_dispatch_key,
             'dispatch_namespace': backend_dispatch_key.lower(),
-            'func_declarations': list(concatMapCodegen(
+            'func_declarations': list(concat_map_codegen(
                 lambda f: dest.gen_lazy_shape_dtype_decl(f, backend_indices[backend_dispatch_key]),
                 grouped_native_functions
             )),
@@ -174,7 +174,7 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
             'namespaced_headers': '',
             'DispatchKey': backend_dispatch_key,
             'dispatch_namespace': backend_dispatch_key.lower(),
-            'ir_declarations': list(concatMapCodegen(
+            'ir_declarations': list(concat_map_codegen(
                 dest.LazyIR(backend_indices[backend_dispatch_key]),
                 grouped_native_functions
             )),
@@ -194,13 +194,13 @@ def run(source_yaml: str, output_dir: str, dry_run: bool, impl_path: Optional[st
                     f"{output_dir}/{backend_key}LazyIr.h",
                 ]],
                 'backend_namespace': backend_dispatch_key.lower(),  # TODO this is not designed yet
-                'lowering_dispatches': list(concatMapCodegen(
+                'lowering_dispatches': list(concat_map_codegen(
                     dest.LazyTsLowering(
                         backend_indices[backend_dispatch_key],
                         dest.LazyTsLowering.TsLoweringTarget.DISPATCH),
                     grouped_native_functions,
                 )),
-                'lowering_definitions': list(concatMapCodegen(
+                'lowering_definitions': list(concat_map_codegen(
                     dest.LazyTsLowering(
                         backend_indices[backend_dispatch_key],
                         dest.LazyTsLowering.TsLoweringTarget.LOWERING),


### PR DESCRIPTION
Summary:
This commit adds full_codegen support for native functions that have
overloaded names, and the commit also adds full_codegen support for
bitwise_and.Tensor and bitwise_and.Scalar to test the implementation.

Test Plan:
test/cpp/build/test_ptltc --gtest_filter=AtenLtcTsTensorTest.TestBitwiseAnd*

Fixes #{issue number}
